### PR TITLE
fix build for GCC < 5.0

### DIFF
--- a/common/cpuid.c
+++ b/common/cpuid.c
@@ -30,10 +30,17 @@ kdb_cpuid_t *kdb_cpuid (void) {
     return &cached;
   }
   int a;
+  #if ( __GNUC__ < 5 ) && defined( __i386__ ) && defined( __PIC__ )
+  asm volatile ("cpuid\n\t"
+      : "=a" (a), "=D" (cached.ebx) , "=c" (cached.ecx), "=d" (cached.edx)
+      : "0" (1)
+      );
+  #else
   asm volatile ("cpuid\n\t"
       : "=a" (a), "=b" (cached.ebx) , "=c" (cached.ecx), "=d" (cached.edx)
       : "0" (1)
       );
+  #endif
   cached.magic = CPUID_MAGIC;
   return &cached;
 }


### PR DESCRIPTION
Workaround for CPUID assembly code in older versions of GCC (<5.0) on i386.

In older versions of GCC EBX register was reserved for use, so for the CPUID code to compile it's necessary to use XCHG (see GCC 4.9 source) or some other register, for example EDI.

There is a blog post about allowing EBX register to be used in GCC 5.0 here: https://software.intel.com/en-us/blogs/2014/12/26/new-optimizations-for-x86-in-upcoming-gcc-50-32bit-pic-mode